### PR TITLE
글 보기 페이지 레이아웃

### DIFF
--- a/pages/post/[id].tsx
+++ b/pages/post/[id].tsx
@@ -1,0 +1,2 @@
+export { default } from  'views/post'
+export { getStaticProps, getStaticPaths } from 'views/post'

--- a/pages/post/[id].tsx
+++ b/pages/post/[id].tsx
@@ -1,2 +1,2 @@
 export { default } from  'views/post'
-export { getStaticProps, getStaticPaths } from 'views/post'
+export { getServerSideProps } from 'views/post'

--- a/views/post/index.tsx
+++ b/views/post/index.tsx
@@ -1,0 +1,39 @@
+import Layout from 'views/components/layout/index';
+import Header from 'views/components/header';
+import Sidebar from 'views/components/sidebar';
+import { GetStaticProps, GetStaticPaths } from 'next';
+import { Post, PostRequestBody } from '../../share/interfaces/post'
+import { getMockdata, posts } from '../../share/utils/mock-data'
+import * as S from './styles';
+
+const PostViewPage = ({ post }) => { 
+    return (
+      <Layout>
+        <Sidebar />
+        <S.PostContent>{post.content}</S.PostContent>
+      </Layout>
+    );
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+    const data = await getMockdata();
+    const paths = data.map(({ id }) => ({
+        params: { id: String(id) },
+    }))
+
+    return { paths, fallback: false }
+};
+
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+    try {
+        const id = params?.id;
+        const item = posts.find((data) => data.id === Number(id));
+        return { props: { post: item }};
+    } catch (err) {
+        console.log(err.message);
+        return { props: { errors: err.message }};
+    }
+    
+};
+  
+export default PostViewPage;

--- a/views/post/index.tsx
+++ b/views/post/index.tsx
@@ -1,16 +1,42 @@
 import Layout from 'views/components/layout/index';
 import Header from 'views/components/header';
 import Sidebar from 'views/components/sidebar';
+import React from 'react';
+import router from 'next/router';
+import ThemeButton from 'views/components/theme-button'
 import { GetStaticProps, GetStaticPaths } from 'next';
 import { Post, PostRequestBody } from '../../share/interfaces/post'
 import { getMockdata, posts } from '../../share/utils/mock-data'
 import * as S from './styles';
 
 const PostViewPage = ({ post }) => { 
+    const handleOnClick = (href: string) => {
+        router.push(href);
+      };
+
+    const deletePost = () => {
+        const deleteCheck = confirm("삭제된 글은 복구가 불가능합니다.\n글을 삭제하시겠습니까?");
+        if (!deleteCheck) return;
+        else return; /* 삭제 구현할 부분 */
+    }
+
     return (
       <Layout>
         <Sidebar />
-        <S.PostContent>{post.content}</S.PostContent>
+        <S.ContentContainer>
+            <S.PostContent>{post.content}</S.PostContent>
+            <S.ButtonContainer>
+                <ThemeButton 
+                text={'수정하기'} 
+                onClick={() => handleOnClick(`/post-input/${post.id}`)} 
+                isBrownTheme={true} />
+                <ThemeButton text={'삭제하기'}
+                onClick={deletePost}
+                isBrownTheme={false}/>
+            </S.ButtonContainer>
+        </S.ContentContainer>
+        
+        
       </Layout>
     );
 };

--- a/views/post/index.tsx
+++ b/views/post/index.tsx
@@ -1,11 +1,9 @@
 import Layout from 'views/components/layout/index';
-import Header from 'views/components/header';
 import Sidebar from 'views/components/sidebar';
 import React from 'react';
 import router from 'next/router';
 import ThemeButton from 'views/components/theme-button'
 import { GetServerSideProps } from 'next';
-import { Post, PostRequestBody } from '../../share/interfaces/post'
 import { getMockdata } from '../../share/utils/mock-data'
 import * as S from './styles';
 

--- a/views/post/index.tsx
+++ b/views/post/index.tsx
@@ -4,9 +4,9 @@ import Sidebar from 'views/components/sidebar';
 import React from 'react';
 import router from 'next/router';
 import ThemeButton from 'views/components/theme-button'
-import { GetStaticProps, GetStaticPaths } from 'next';
+import { GetServerSideProps } from 'next';
 import { Post, PostRequestBody } from '../../share/interfaces/post'
-import { getMockdata, posts } from '../../share/utils/mock-data'
+import { getMockdata } from '../../share/utils/mock-data'
 import * as S from './styles';
 
 const PostViewPage = ({ post }) => { 
@@ -34,32 +34,15 @@ const PostViewPage = ({ post }) => {
                 onClick={deletePost}
                 isBrownTheme={false}/>
             </S.ButtonContainer>
-        </S.ContentContainer>
-        
-        
+        </S.ContentContainer>      
       </Layout>
     );
 };
 
-export const getStaticPaths: GetStaticPaths = async () => {
-    const data = await getMockdata();
-    const paths = data.map(({ id }) => ({
-        params: { id: String(id) },
-    }))
-
-    return { paths, fallback: false }
-};
-
-export const getStaticProps: GetStaticProps = async ({ params }) => {
-    try {
-        const id = params?.id;
-        const item = posts.find((data) => data.id === Number(id));
-        return { props: { post: item }};
-    } catch (err) {
-        console.log(err.message);
-        return { props: { errors: err.message }};
-    }
-    
-};
-  
+export const getServerSideProps: GetServerSideProps = async (context) => {
+    const id = context.params?.id;
+    const posts = await getMockdata();
+    const item = posts.find((data) => data.id === Number(id));
+    return { props: { post: item }};
+}
 export default PostViewPage;

--- a/views/post/index.tsx
+++ b/views/post/index.tsx
@@ -8,10 +8,6 @@ import { getMockdata } from '../../share/utils/mock-data'
 import * as S from './styles';
 
 const PostViewPage = ({ post }) => { 
-    const handleOnClick = (href: string) => {
-        router.push(href);
-      };
-
     const deletePost = () => {
         const deleteCheck = confirm("삭제된 글은 복구가 불가능합니다.\n글을 삭제하시겠습니까?");
         if (!deleteCheck) return;
@@ -26,7 +22,7 @@ const PostViewPage = ({ post }) => {
             <S.ButtonContainer>
                 <ThemeButton 
                 text={'수정하기'} 
-                onClick={() => handleOnClick(`/post-input/${post.id}`)} 
+                onClick={() => router.replace('/post')} 
                 isBrownTheme={true} />
                 <ThemeButton text={'삭제하기'}
                 onClick={deletePost}

--- a/views/post/styles.ts
+++ b/views/post/styles.ts
@@ -7,3 +7,19 @@ export const PostContent = styled.div`
   background-color: white;
   color: black;
 `;
+
+export const ButtonContainer = styled.div`
+  width: 300px;
+  margin-top: 15px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`
+
+export const ContentContainer = styled.div`
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+`

--- a/views/post/styles.ts
+++ b/views/post/styles.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const PostContent = styled.div`
+  width: 100%;
+  padding: 15px;
+  
+  background-color: white;
+  color: black;
+`;


### PR DESCRIPTION
- mock data의 content 받아와서 페이지 라우팅 하는 것 구현했습니다.
- view 폴더 내에 post 라는 이름의 폴더를 만들어서 작업했습니다. (pages 폴더 내의 post 폴더와 이름을 동일하게 하려고 post로 설정했어요..!)
- 작업할 당시 mood 기능 추가 반영이 안되어있어서 글 보기 페이지에서 내용(content) 외에 mood 를 보여주는 부분은 아직 넣지 않았는데, ~~mood 기능 관련한 수정사항 merge 된 것 방금 확인했고 곧 다시 수정해서 올리겠습니다!~~ 가 아니네요 ,, dto 수정된 것 merge를 착각했습니다 ,, 