### PR TITLE
[css] 글로벌 레이아웃 너비 수정

### DIFF
--- a/views/components/header/index.tsx
+++ b/views/components/header/index.tsx
@@ -1,16 +1,16 @@
-import { useUser } from 'common/context/user/user';
+import { useUserContext } from 'common/context/user/user';
 import Link from 'next/link';
 import React from 'react';
 import * as S from './styles';
 
 const Header: React.FC = () => {
-  const user = useUser();
+  const { user } = useUserContext();
 
   return (
     <S.Header>
       <Link href='/'>
         <S.BlogTitle>
-          {user.blogTitle} <S.StyleLine />
+          {user && user.blogTitle} <S.StyleLine />
         </S.BlogTitle>
       </Link>
     </S.Header>

--- a/views/components/header/styles.ts
+++ b/views/components/header/styles.ts
@@ -1,3 +1,4 @@
+import { THEME_COLOR } from 'common/constant';
 import styled from 'styled-components';
 
 export const Header = styled.header`
@@ -15,9 +16,9 @@ export const BlogTitle = styled.a`
   width: 100%;
   height: 200px;
 
-  font-size: 50px;
-  font-weight: bolder;
-  color: #c1b7b7;
+  font-size: 30px;
+  font-weight: 800;
+  color: ${THEME_COLOR.BROWN};
 `;
 
 export const StyleLine = styled.div`

--- a/views/components/layout/styles.ts
+++ b/views/components/layout/styles.ts
@@ -1,11 +1,13 @@
 import styled from 'styled-components';
 
 export const Layout = styled.div`
-  display: table;
+  display: flex;
+  flex-direction: column;
+  /* display: table; */
   margin-left: auto;
   margin-right: auto;
 
-  width: 100%;
+  width: 1200px;
   height: 100%;
   max-width: 1500px;
   min-width: 1000px;
@@ -13,6 +15,8 @@ export const Layout = styled.div`
   padding: 0 100px;
   padding-top: 10px;
   background-color: #f1f0ef;
+
+  align-items: center;
 `;
 
 export const Content = styled.div`

--- a/views/components/sidebar/styles.ts
+++ b/views/components/sidebar/styles.ts
@@ -1,10 +1,13 @@
+import { THEME_COLOR } from 'common/constant';
 import styled from 'styled-components';
 
 export const Sidebar = styled.div`
   display: flex;
   flex-direction: column;
 
-  width: 300px;
+  width: 200px;
+  height: 1000px;
+
   padding: 15px;
   margin-right: 15px;
   margin-bottom: 15px;
@@ -15,9 +18,29 @@ export const Sidebar = styled.div`
 
 export const UserProfile = styled.div`
   width: 100%;
+  height: 30px;
+
   margin-bottom: 10px;
 
   color: #7b6d6c;
   font-weight: bolder;
   font-size: 15px;
+
+  display: flex;
+  align-items: center;
+`;
+
+export const LogoutButton = styled.button`
+  border: 1px solid #c1b7b7;
+  background-color: transparent;
+  width: 50px;
+  float: right;
+  height: 20px;
+  font-size: 10px;
+  margin-left: auto;
+  :hover {
+    background-color: #c1b7b7;
+  }
+
+  color: ${THEME_COLOR.BROWN};
 `;

--- a/views/index/diarybox/styles.ts
+++ b/views/index/diarybox/styles.ts
@@ -1,8 +1,7 @@
 import styled from 'styled-components';
 
 export const DiaryBox = styled.div`
-  width: 900px;
-  height: 110px;
+  width: 100%;
   margin-bottom: 10px;
 
   cursor: pointer;

--- a/views/index/styles.ts
+++ b/views/index/styles.ts
@@ -55,3 +55,12 @@ export const DiaryBoxContainer = styled.div`
 export const SearchBox = styled.div`
   margin: 30px;
 `;
+
+export const CalendarContainer = styled.div`
+  width: 100%;
+  height: 100% auto;
+
+  background-color: white;
+  padding: 30px 40px;
+  margin-bottom: 30px;
+`;


### PR DESCRIPTION
- 고친 css 내용:  
  - 전체 컨텐트 사이즈를 1200px로 고정 
  - 사이드바 크기 줄임
  - 헤더 폰트 크기와 두께 수정

- 고친 이유:  달력 기능상 한눈에 보이지 않음 + 맥 크롬에서 배율 100%일 경우 너비스크롤 생김



전)
<img width="400" alt="스크린샷 2021-06-18 오후 8 21 20" src="https://user-images.githubusercontent.com/37537202/122556290-478be180-d076-11eb-8504-b2f71e640182.png">
후)
<img width="400" alt="스크린샷 2021-06-18 오후 8 23 53" src="https://user-images.githubusercontent.com/37537202/122556294-4955a500-d076-11eb-9deb-6832216e4837.png">


ui작업하실때 영향받을거같아서, pull해서 적용해보시고 괜찮다면 코멘트남겨주시면 바로 머지할게요!


