### PR TITLE
무드별 검색 페이지를 구현합니다.

### DIFF
--- a/common/api/postAPI.ts
+++ b/common/api/postAPI.ts
@@ -63,7 +63,7 @@ const postAPI = {
     return posts;
   },
 
-  getPostsByMoodId: async (moodId: number, page: number): Promise<Post[]> => {
+  getPostsByMoodId: async (moodId: number, page: number): Promise<PagedPosts> => {
     const posts = await axios
       .get<Post[]>(`${endpoints.POST_API}/mood/${moodId}?page=${page}`)
       .catch((err) => {

--- a/pages/mood/index.tsx
+++ b/pages/mood/index.tsx
@@ -1,0 +1,2 @@
+export { default } from 'views/mood';
+export { getServerSideProps } from 'views/mood';

--- a/server/routes/post.ts
+++ b/server/routes/post.ts
@@ -27,7 +27,7 @@ postRouter.get('/mood/:id', async (req: Request, res: Response) => {
   const moodId = parseInt(req.params.id);
   const page = parseInt(req.query.page as string);
 
-  const posts: Post[] | void = await PostService.getPostsByMoodId(userId, moodId, page).catch(
+  const posts: PagedPosts | void = await PostService.getPostsByMoodId(userId, moodId, page).catch(
     (err) => {
       console.error(err);
       res.status(500).send({ error: '서버 점검중입니다. 잠시 후 다시 시도해주세요!' });

--- a/server/service/postService.ts
+++ b/server/service/postService.ts
@@ -32,11 +32,11 @@ export default class PostService {
     userId: number,
     moodId: number,
     page: number
-  ): Promise<Post[]> {
+  ): Promise<PagedPosts> {
     const take = POSTS_PER_PAGE;
     const skip = (page - 1) * POSTS_PER_PAGE;
 
-    const [data] = await DBPool.query(
+    const [postsData] = await DBPool.query(
       `select * from post where userId = ? and moodId = ? 
        ORDER BY id DESC LIMIT ? OFFSET ?`,
       [userId, moodId, take, skip]
@@ -45,7 +45,15 @@ export default class PostService {
       throw new Error();
     });
 
-    return parseRawData(data);
+    const [totalData] = await DBPool.query(
+      `select count(*) as total from post where userId = ? and moodId = ?`,
+      [userId, moodId]
+    );
+
+    const [data] = parseRawData(totalData);
+    data.posts = parseRawData(postsData);
+
+    return data;
   }
 
   // 검색기능

--- a/views/components/sidebar/index.tsx
+++ b/views/components/sidebar/index.tsx
@@ -10,6 +10,8 @@ import getRecentMoodId from './utils/getRecentMoodId';
 import { useState } from 'react';
 
 import 'antd/lib/card/style/index.css';
+import Image from 'next/image';
+import { MOOD_ICONS } from 'common/constant';
 
 const Sidebar: React.FC = () => {
   const [currentMoodId, setCurrentMoodId] = useState(1);
@@ -18,6 +20,7 @@ const Sidebar: React.FC = () => {
   const handleOnClick = (href: string) => {
     router.push(href);
   };
+
   React.useEffect(() => {
     const setTodayQuote = async () => {
       const recentMoodId = await getRecentMoodId();
@@ -43,6 +46,7 @@ const Sidebar: React.FC = () => {
         return undefined;
     }
   }, [currentMoodId]);
+
   const logout = () => {
     window.location.href = process.env.API_BASE_URL + '/auth/logout';
   };
@@ -62,6 +66,33 @@ const Sidebar: React.FC = () => {
         <Card title='오늘의 편지'>{quote}</Card>
       </S.PCard>
       <SearchBar />
+      <div>
+        <p>기분별 일기 조회하기</p>
+        <S.MoodIcon>
+          <Image
+            onClick={() => router.push('/mood?moodId=1')}
+            src={'/' + MOOD_ICONS[0].src}
+            width='48px'
+            height='48px'
+          />
+        </S.MoodIcon>
+        <S.MoodIcon>
+          <Image
+            onClick={() => router.push('/mood?moodId=2')}
+            src={'/' + MOOD_ICONS[1].src}
+            width='48px'
+            height='48px'
+          />
+        </S.MoodIcon>
+        <S.MoodIcon>
+          <Image
+            onClick={() => router.push('/mood?moodId=3')}
+            src={'/' + MOOD_ICONS[2].src}
+            width='48px'
+            height='48px'
+          />
+        </S.MoodIcon>
+      </div>
     </S.Sidebar>
   );
 };

--- a/views/components/sidebar/index.tsx
+++ b/views/components/sidebar/index.tsx
@@ -1,5 +1,5 @@
 import { useUser } from 'common/context/user/user';
-import router from 'next/router';
+import router, { useRouter } from 'next/router';
 import React from 'react';
 import ThemeButton from 'views/components/theme-button';
 import * as S from './styles';
@@ -14,6 +14,9 @@ import Image from 'next/image';
 import { MOOD_ICONS } from 'common/constant';
 
 const Sidebar: React.FC = () => {
+  const {
+    query: { moodId },
+  } = useRouter();
   const [currentMoodId, setCurrentMoodId] = useState(1);
   const [quote, setQuote] = useState('');
   const user = useUser();
@@ -68,30 +71,16 @@ const Sidebar: React.FC = () => {
       <SearchBar />
       <div>
         <p>기분별 일기 조회하기</p>
-        <S.MoodIcon>
-          <Image
-            onClick={() => router.push('/mood?moodId=1')}
-            src={'/' + MOOD_ICONS[0].src}
-            width='48px'
-            height='48px'
-          />
-        </S.MoodIcon>
-        <S.MoodIcon>
-          <Image
-            onClick={() => router.push('/mood?moodId=2')}
-            src={'/' + MOOD_ICONS[1].src}
-            width='48px'
-            height='48px'
-          />
-        </S.MoodIcon>
-        <S.MoodIcon>
-          <Image
-            onClick={() => router.push('/mood?moodId=3')}
-            src={'/' + MOOD_ICONS[2].src}
-            width='48px'
-            height='48px'
-          />
-        </S.MoodIcon>
+        {[1, 2, 3].map((mood) => (
+          <S.MoodIcon key={mood} isSelected={parseInt(moodId as string) === mood}>
+            <Image
+              onClick={() => router.push(`/mood?moodId=${mood}`)}
+              src={'/' + MOOD_ICONS[mood - 1].src}
+              width='48px'
+              height='48px'
+            />
+          </S.MoodIcon>
+        ))}
       </div>
     </S.Sidebar>
   );

--- a/views/components/sidebar/index.tsx
+++ b/views/components/sidebar/index.tsx
@@ -69,8 +69,8 @@ const Sidebar: React.FC = () => {
         <Card title='오늘의 편지'>{quote}</Card>
       </S.PCard>
       <SearchBar />
-      <div>
-        <p>기분별 일기 조회하기</p>
+      <S.MoodSearchBox>
+        <S.MoodUpContent>기분별 일기 조회</S.MoodUpContent>
         {[1, 2, 3].map((mood) => (
           <S.MoodIcon key={mood} isSelected={parseInt(moodId as string) === mood}>
             <Image
@@ -81,7 +81,7 @@ const Sidebar: React.FC = () => {
             />
           </S.MoodIcon>
         ))}
-      </div>
+      </S.MoodSearchBox>
     </S.Sidebar>
   );
 };

--- a/views/components/sidebar/styles.ts
+++ b/views/components/sidebar/styles.ts
@@ -53,3 +53,8 @@ export const PCard = styled.div<PCardProps>`
   background: ${(props) => props.backgroundColor ?? '#7d5a5a'};
   padding: 10px;
 `;
+
+export const MoodIcon = styled.button`
+  border: none;
+  background: none;
+`;

--- a/views/components/sidebar/styles.ts
+++ b/views/components/sidebar/styles.ts
@@ -54,7 +54,18 @@ export const PCard = styled.div<PCardProps>`
   padding: 10px;
 `;
 
-export const MoodIcon = styled.button`
+interface MoodIconProps {
+  isSelected?: boolean;
+}
+
+export const MoodIcon = styled.button<MoodIconProps>`
   border: none;
   background: none;
+  opacity: ${(props) => (props.isSelected ? '1' : '0.7')};
+
+  :hover,
+  :active,
+  :focus {
+    opacity: 1;
+  }
 `;

--- a/views/components/sidebar/styles.ts
+++ b/views/components/sidebar/styles.ts
@@ -52,6 +52,8 @@ interface PCardProps {
 export const PCard = styled.div<PCardProps>`
   background: ${(props) => props.backgroundColor ?? '#7d5a5a'};
   padding: 10px;
+  margin-bottom: 30px;
+  margin-top: 30px;
 `;
 
 interface MoodIconProps {
@@ -68,4 +70,20 @@ export const MoodIcon = styled.button<MoodIconProps>`
   :focus {
     opacity: 1;
   }
+`;
+
+export const MoodSearchBox = styled.div`
+  border: 2px solid;
+  border-color: ${THEME_COLOR.BROWN};
+  margin-top: 30px;
+  padding: 3px;
+`;
+
+export const MoodUpContent = styled.div`
+  color: ${THEME_COLOR.BROWN};
+  padding: 3px;
+  margin-left: auto;
+  font-size: 13px;
+  justify-content: center;
+  font-weight: bolder;
 `;

--- a/views/mood/hooks/usePagedPosts.ts
+++ b/views/mood/hooks/usePagedPosts.ts
@@ -1,0 +1,42 @@
+import { Post } from 'share/interfaces/post';
+import { useEffect, useMemo, useState } from 'react';
+import { useCallback } from 'react';
+import { POSTS_PER_PAGE } from 'share/constant';
+import postAPI from 'common/api/postAPI';
+
+interface UsePagedPostsProps {
+  initialPosts: Post[];
+  total: number;
+  moodId: number;
+}
+
+export const usePagedPosts = ({ initialPosts, total, moodId }: UsePagedPostsProps) => {
+  const [pagedPosts, setPagedPosts] = useState(initialPosts);
+  const pageCount = useMemo(() => Math.ceil(total / POSTS_PER_PAGE), [total]);
+
+  useEffect(() => {
+    setPagedPosts(initialPosts);
+  }, [moodId, initialPosts]);
+
+  const changePage = useCallback(
+    async ({ selected }: { selected: number }) => {
+      const getPostsByPage = (selected: number) => async () => {
+        const pagedPosts = await postAPI.getPostsByMoodId(moodId, selected + 1); // TODO: use SWR later?
+
+        if (!pagedPosts) return;
+
+        const { posts } = pagedPosts;
+        setPagedPosts(posts);
+      };
+
+      getPostsByPage(selected)();
+    },
+    [moodId]
+  );
+
+  return {
+    pagedPosts,
+    pageCount,
+    changePage,
+  };
+};

--- a/views/mood/index.tsx
+++ b/views/mood/index.tsx
@@ -1,0 +1,90 @@
+import Layout from 'views/components/layout/index';
+import { NextPage } from 'next';
+import * as S from 'views/index/styles';
+import Sidebar from 'views/components/sidebar';
+import Diarybox from 'views/index/diarybox';
+import React from 'react';
+import ReactPaginate from 'react-paginate';
+import postAPI from 'common/api/postAPI';
+import Emptybox from 'views/index/emptybox';
+import { PagedPosts, Post } from 'share/interfaces/post';
+import MoodCalendar from 'views/index/mood-calendar';
+import { usePagedPosts } from './hooks/usePagedPosts';
+import { useRouter } from 'next/router';
+
+interface MoodPageProps {
+  initialPosts: Post[];
+  total: number;
+  moodId?: number;
+}
+
+const MoodPage: NextPage<MoodPageProps> = ({ initialPosts, moodId, total }) => {
+  const router = useRouter();
+
+  React.useEffect(() => {
+    if (![1, 2, 3].includes(moodId)) {
+      alert('존재하지 않는 moodId입니다!');
+      router.back();
+    }
+  }, [router, moodId]);
+
+  const { pageCount, changePage, pagedPosts } = usePagedPosts({ initialPosts, total, moodId });
+
+  return (
+    <Layout>
+      <Sidebar />
+      <S.Mainpage>
+        <S.CalendarContainer>
+          <MoodCalendar />
+        </S.CalendarContainer>
+        <S.DiaryListContainer>
+          <S.Diaryinfo>나의 일기들</S.Diaryinfo>
+          <S.DiaryBoxContainer>
+            {pagedPosts.length ? (
+              pagedPosts.map((post) => {
+                return <Diarybox key={post.id} post={post} />;
+              })
+            ) : (
+              <Emptybox />
+            )}
+          </S.DiaryBoxContainer>
+          <S.Pgbox>
+            {pageCount > 0 && (
+              <ReactPaginate
+                pageRangeDisplayed={2}
+                marginPagesDisplayed={3}
+                previousLabel={'이전'}
+                nextLabel={'다음'}
+                pageCount={pageCount}
+                onPageChange={changePage}
+                containerClassName={'pagebtn'}
+                activeClassName={'page_active_btn'}
+              />
+            )}
+          </S.Pgbox>
+        </S.DiaryListContainer>
+      </S.Mainpage>
+    </Layout>
+  );
+};
+
+export default MoodPage;
+
+export async function getServerSideProps({ query }) {
+  const { moodId: rawMoodId } = query;
+  const moodId = parseInt(rawMoodId);
+
+  if (![1, 2, 3].includes(moodId)) {
+    return { props: { total: 0, initialPosts: [], moodId: 0 } };
+  }
+
+  const data: PagedPosts = await postAPI.getPostsByMoodId(moodId, 1);
+
+  if (!data) {
+    return { props: { total: 0, initialPosts: [], moodId } };
+  }
+
+  const { total, posts } = data;
+
+  return { props: { total, initialPosts: posts, moodId } };
+}


### PR DESCRIPTION
무드별 검색 페이지를 구현합니다.
자세한 사항은 feature/search 에서 적용한 사항들과 같습니다.

- getPostsByMoodId API 수정
- 무드별 검색 페이지 추가/ 페이지네이션 적용
- mood 버튼이 선택되었는지에 따라 투명도 조절로 구분
- 
![image](https://user-images.githubusercontent.com/58072776/122673726-c024a680-d20c-11eb-85d4-3aeff4d06b6b.png)
